### PR TITLE
Fixed wrong argument call on Mac OSX

### DIFF
--- a/build/dblite.node.js
+++ b/build/dblite.node.js
@@ -129,9 +129,9 @@ function dblite() {
 
   var
     // this is the delimiter of each sqlite3 shell command
-    SUPER_SECRET =  //'---' +
-                    crypto.randomBytes(64).toString('base64'),
-                    //'---',
+    SUPER_SECRET =  '---' +
+                    crypto.randomBytes(64).toString('base64') +
+                    '---',
     // ... I wish .print was introduced before SQLite 3.7.10 ...
     // this is a weird way to get rid of the header, if enabled
     SUPER_SECRET_SELECT = '"' + SUPER_SECRET + '" AS "' + SUPER_SECRET + '";' + EOL,
@@ -148,11 +148,11 @@ function dblite() {
       // executable only, folder needs to be specified a part
       bin.length === 1 ? bin[0] : ('.' + PATH_SEP + bin[bin.length - 1]),
       // normalize file path if not :memory:
-      normalizeFirstArgument(
+      Array.prototype.reverse.call(normalizeFirstArgument(
         // it is possible to eventually send extra sqlite3 args
         // so all arguments are passed
         Array.prototype.slice.call(arguments)
-      ).concat('-csv'), // but the output MUST be csv
+      ).concat('-csv')), // but the output MUST be csv
       // be sure the dir is the right one
       {
         // the right folder is important or sqlite3 won't work

--- a/src/dblite.js
+++ b/src/dblite.js
@@ -126,11 +126,11 @@ function dblite() {
       // executable only, folder needs to be specified a part
       bin.length === 1 ? bin[0] : ('.' + PATH_SEP + bin[bin.length - 1]),
       // normalize file path if not :memory:
-      normalizeFirstArgument(
+      Array.prototype.reverse.call(normalizeFirstArgument(
         // it is possible to eventually send extra sqlite3 args
         // so all arguments are passed
         Array.prototype.slice.call(arguments)
-      ).concat('-csv'), // but the output MUST be csv
+      ).concat('-csv')), // but the output MUST be csv
       // be sure the dir is the right one
       {
         // the right folder is important or sqlite3 won't work


### PR DESCRIPTION
I fixed a problem occured on mac osx. 
I always got an error when executing a query. 
This was caused in a wrong call of sqlite3. 

Non working call: 

``` bash
sqlite3 :memory: -csv -header
```

Working call: 

``` bash
sqlite3 -csv -header :memory:
```

Otherwise it does not work on mac osx. 
