### PR TITLE
[cadence] handle cadence callback signature

### DIFF
--- a/build/dblite.node.js
+++ b/build/dblite.node.js
@@ -347,7 +347,8 @@ function dblite() {
               result
             ;
             // if there was an error signature
-            if (1 < callback.length) {
+            // (if invoked under cadence, cb.length === 0)
+            if (1 !== callback.length) {
               callback.call(self, null, rows);
             } else {
               // invoke it with the db object as context


### PR DESCRIPTION
hi there! when using the https://github.com/bigeasy/cadence package, it wraps callbacks in a function that has zero parameters, so the test on line 250 would fail. now it doesn't!