### PR TITLE
Do not detach child process

### DIFF
--- a/src/dblite.js
+++ b/src/dblite.js
@@ -92,7 +92,6 @@ var
         cwd: bin.slice(0, -1).join(PATH_SEP) || process.cwd(),
         env: process.env, // same env is OK
         encoding: 'utf8', // utf8 is OK
-        detached: true,   // asynchronous
         stdio: ['pipe', 'pipe', 'pipe'] // handled here
       }
     );
@@ -978,9 +977,10 @@ var db =
 db.query('PRAGMA table_info(kvp)');
 
 // to test memory database
+db.close();
 var db = require('./build/dblite.node.js')(':memory:');
 db.query('CREATE TABLE test (key INTEGER PRIMARY KEY, value TEXT)') && undefined;
 db.query('INSERT INTO test VALUES(null, "asd")') && undefined;
 db.query('SELECT * FROM test') && undefined;
-// db.close();
+db.close();
 */


### PR DESCRIPTION
The comments said "asynchronous", but that's not what detached means, it
allows the child to live beyond the parent under some conditions (exact
conditions vary between Windows and non-Windows). `sqlite3` living
longer than the parent process is probably not a good thing.

- https://nodejs.org/api/child_process.html#child_process_options_detached