### PR TITLE
Fix SELECT identification

### DIFF
--- a/src/dblite.js
+++ b/src/dblite.js
@@ -42,7 +42,7 @@ var
   // use to re-generate Date objects
   DECIMAL = /^[1-9][0-9]*$/,
   // verify if it's a select or not
-  SELECT = /^(?:select|SELECT|pragma|PRAGMA|with|WITH) /,
+  SELECT = /^\s?(?:select|SELECT|pragma|PRAGMA|with|WITH) /,
   // for simple query replacements: WHERE field = ?
   REPLACE_QUESTIONMARKS = /\?/g,
   // for named replacements: WHERE field = :data

--- a/src/dblite.js
+++ b/src/dblite.js
@@ -42,7 +42,7 @@ var
   // use to re-generate Date objects
   DECIMAL = /^[1-9][0-9]*$/,
   // verify if it's a select or not
-  SELECT = /^\s?(?:select|SELECT|pragma|PRAGMA|with|WITH) /,
+  SELECT = /^\s*(?:select|SELECT|pragma|PRAGMA|with|WITH) /,
   // for simple query replacements: WHERE field = ?
   REPLACE_QUESTIONMARKS = /\?/g,
   // for named replacements: WHERE field = :data


### PR DESCRIPTION
Correctly identify SELECT/PRAGMA/etc statements that start with whitespace (eg: a new line) instead of ignoring them

---

This pull request fixes a problem I noticed while working on a recent project. When identifying SELECT/etc statements, the regex used ignores statements that start with whitespace. So for example, this:
```js
db.query(`
    SELECT * FROM tests WHERE
    user_id = ? AND
    memo_id = ?
`, ['abc', 'defg'])
```

\- wouldn't correctly be recognized as a SELECT statement because of the whitespace (new line) at the beginning. This whitespace doesn't affect other query types because they aren't checked the same way, and this creates confusing/inconsistent behavior (from personal experience: it stumped me for two days 🙃)

The fix I've added just adds a ~~`\s?`~~ `\s*` bit at the start of the regex in order to check for any whitespace that may be there. If this won't work, feel free to change it- it's just the simplest fix I could come up with